### PR TITLE
am - added delete and update operations in the controller and edited …

### DIFF
--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/ShiftController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/ShiftController.java
@@ -3,20 +3,27 @@ package edu.ucsb.cs156.gauchoride.controllers;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import edu.ucsb.cs156.gauchoride.entities.Ride;
 import edu.ucsb.cs156.gauchoride.entities.Shift;
 import edu.ucsb.cs156.gauchoride.repositories.ShiftRepository;
 import edu.ucsb.cs156.gauchoride.repositories.UserRepository;
 import edu.ucsb.cs156.gauchoride.errors.EntityNotFoundException;
 import edu.ucsb.cs156.gauchoride.models.CurrentUser;
 
+import java.nio.file.AccessDeniedException;
 import java.time.LocalTime;
+
+import javax.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -62,11 +69,11 @@ public class ShiftController extends ApiController {
     @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER')")
     @PostMapping("/post")
     public Shift postShift(
-        @Parameter(name="day") @RequestParam String day,
-        @Parameter(name="shiftStart") @RequestParam String shiftStart,
-        @Parameter(name="shiftEnd") @RequestParam String shiftEnd,
-        @Parameter(name="driverID") @RequestParam long driverID ,
-        @Parameter(name="driverBackupID") @RequestParam long driverBackupID
+        @Parameter(name="day", description ="String, day of the week", example = "Monday") @RequestParam String day,
+        @Parameter(name="shiftStart", description="String, Format: HH:MM(A/P)M", example="11:00AM") @RequestParam String shiftStart,
+        @Parameter(name="shiftEnd", description="String, Format: HH:MM(A/P)M", example="11:00AM") @RequestParam String shiftEnd,
+        @Parameter(name="driverID", description = "Long, driver ID") @RequestParam long driverID ,
+        @Parameter(name="driverBackupID", description = "Long, driver backup id") @RequestParam long driverBackupID
         )
         {
 
@@ -82,4 +89,60 @@ public class ShiftController extends ApiController {
 
         return savedShift;
     }
+
+
+
+    @Operation(summary= "Delete a Shift, drivers can only delete their own")
+    @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER')")
+    @DeleteMapping("")
+    public Object deleteShift(
+        @Parameter(name="id", description = "Long, id number of shift to get", example = "1", required = true) 
+        @RequestParam long id){
+            Shift shift = shiftRepository.findById(id)
+                    .orElseThrow(() -> new EntityNotFoundException(Shift.class, id));
+
+            
+            if (!getCurrentUser().getRoles().contains(new SimpleGrantedAuthority("ROLE_ADMIN"))){
+                if((getCurrentUser().getUser().getId() != shift.getDriverID())){
+                    throw new EntityNotFoundException(Shift.class, id);
+                }
+            }
+
+    
+            shiftRepository.delete(shift);
+            return genericMessage("Shift with id %s deleted".formatted(id));
+
+    }
+
+
+    @Operation(summary = "Update a single shift, drivers can only update their own")
+    @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER')")
+    @PutMapping("")
+    public Shift updateShift(
+            @Parameter(name="id", description = "Long, id number of shift to get", example = "1", required = true)
+            @RequestParam Long id,
+            @RequestBody @Valid Shift incoming) {
+
+        Shift shift = shiftRepository.findById(id)
+                    .orElseThrow(() -> new EntityNotFoundException(Shift.class, id));
+
+        
+        if (!getCurrentUser().getRoles().contains(new SimpleGrantedAuthority("ROLE_ADMIN"))){
+                if((getCurrentUser().getUser().getId() != shift.getDriverID())){
+                    throw new EntityNotFoundException(Shift.class, id);
+                }
+            }
+
+        
+        shift.setDay(incoming.getDay());
+        shift.setShiftStart(incoming.getShiftStart());
+        shift.setShiftEnd(incoming.getShiftEnd());
+        shift.setDriverID(getCurrentUser().getUser().getId());
+        shift.setDriverBackupID(incoming.getDriverBackupID());
+
+        shiftRepository.save(shift);
+
+        return shift;
+    }
+
 }

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/ShiftControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/ShiftControllerTests.java
@@ -3,6 +3,7 @@ package edu.ucsb.cs156.gauchoride.controllers;
 import edu.ucsb.cs156.gauchoride.repositories.UserRepository;
 import edu.ucsb.cs156.gauchoride.testconfig.TestConfig;
 import edu.ucsb.cs156.gauchoride.ControllerTestCase;
+import edu.ucsb.cs156.gauchoride.entities.Ride;
 import edu.ucsb.cs156.gauchoride.entities.Shift;
 import edu.ucsb.cs156.gauchoride.repositories.ShiftRepository;
 
@@ -13,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -48,7 +50,7 @@ public class ShiftControllerTests extends ControllerTestCase {
 
         @WithMockUser(roles = { "USER" })
         @Test
-        public void logged_in_users_can_get_all_of_theirs() throws Exception {
+        public void logged_in_users_can_get_all() throws Exception {
                 mockMvc.perform(get("/api/shift/all"))
                                 .andExpect(status().is(200)); // logged
         }
@@ -73,6 +75,13 @@ public class ShiftControllerTests extends ControllerTestCase {
         public void logged_out_users_cannot_get_by_id() throws Exception {
                 mockMvc.perform(get("/api/shift/get?id=7"))
                                 .andExpect(status().is(403)); // logged out users can't get by id
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_can_get_by_id() throws Exception {
+                mockMvc.perform(get("/api/shift/get?id=7"))
+                                .andExpect(status().is(404)); // logged out users can't get by id
         }
 
 
@@ -105,8 +114,41 @@ public class ShiftControllerTests extends ControllerTestCase {
                                 .andExpect(status().is(403));
         }
 
-        // // Tests with mocks for database actions
 
+        // Authorization tests for delete /api/shift
+
+        @Test
+         public void logged_out_users_cannot_delete() throws Exception {
+                 mockMvc.perform(delete("/api/shift?id=9"))
+                                 .andExpect(status().is(403));
+        }
+
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+         public void logged_in_users_cannot_delete() throws Exception {
+                 mockMvc.perform(delete("/api/shift?id=9"))
+                                 .andExpect(status().is(403));
+        }
+
+
+        // Authorization tests for put /api/shift
+
+        @Test
+        public void logged_out_users_cannot_edit() throws Exception {
+                 mockMvc.perform(put("/api/shift?id=9"))
+                                 .andExpect(status().is(403));
+        }
+        
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_cannot_edit() throws Exception {
+                 mockMvc.perform(put("/api/shift?id=9"))
+                                 .andExpect(status().is(403));
+        }
+
+
+        // // Tests with mocks for database actions
 
 
         // GET BY ID
@@ -449,4 +491,330 @@ public class ShiftControllerTests extends ControllerTestCase {
                 String responseString = response.getResponse().getContentAsString();
                 assertEquals(expectedJson, responseString);
         }
+
+
+        
+        
+
+        // DELETE
+
+        @WithMockUser(roles = { "DRIVER" })
+        @Test
+        public void driver_can_delete_their_own_shift() throws Exception {
+                // arrange
+
+                long userId = currentUserService.getCurrentUser().getUser().getId();
+
+                Shift shift1 = Shift.builder()
+                                .driverID(userId)
+                                .day("Monday")
+                                .shiftStart("10:30AM")
+                                .shiftEnd("12:30PM")
+                                .driverBackupID(1)
+                                .build();
+
+                when(shiftRepository.findById(eq(15L))).thenReturn(Optional.of(shift1));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/shift?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assertuserId
+                verify(shiftRepository, times(1)).findById(15L);
+                verify(shiftRepository, times(1)).delete(shift1);
+
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("Shift with id 15 deleted", json.get("message"));
+        }
+
+
+        @WithMockUser(roles = { "DRIVER" })
+        @Test
+        public void driver_tries_to_delete_other_drivers_shift_and_fails()
+                        throws Exception {
+                // arrange
+
+                long userId = currentUserService.getCurrentUser().getUser().getId();
+                long otherUserId = userId + 1;
+
+                Shift shift1 = Shift.builder()
+                                .driverID(otherUserId)
+                                .day("Monday")
+                                .shiftStart("10:30AM")
+                                .shiftEnd("12:30PM")
+                                .driverBackupID(1)
+                                .build();
+
+                //when(shiftRepository.save(eq(shift1))).thenReturn(shift1);
+                when(shiftRepository.findById(eq(15L))).thenReturn(Optional.of(shift1));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/shift?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(shiftRepository, times(1)).findById(eq(15L));
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("Shift with id 15 not found", json.get("message"));
+        }
+        
+        @WithMockUser(roles = { "DRIVER" })
+        @Test
+        public void driver_tries_to_delete_non_existant_shift_and_gets_right_error_message()
+                        throws Exception {
+                // arrange
+
+                when(shiftRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/shift?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(shiftRepository, times(1)).findById(eq(15L));
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("Shift with id 15 not found", json.get("message"));
+        }
+
+        
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void admin_can_delete_any_shift() throws Exception {
+                // arrange
+
+                long userId = currentUserService.getCurrentUser().getUser().getId();
+                long otherUserId = userId + 1;
+
+                Shift shift1 = Shift.builder()
+                                .driverID(otherUserId)
+                                .day("Monday")
+                                .shiftStart("10:30AM")
+                                .shiftEnd("12:30PM")
+                                .driverBackupID(1)
+                                .build();
+
+                when(shiftRepository.findById(eq(15L))).thenReturn(Optional.of(shift1));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/shift?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(shiftRepository, times(1)).findById(15L);
+                verify(shiftRepository, times(1)).delete(shift1);
+
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("Shift with id 15 deleted", json.get("message"));
+        }
+
+        
+
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void admin_tries_to_delete_non_existant_shift_and_gets_right_error_message()
+                        throws Exception {
+                // arrange
+
+                when(shiftRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/shift?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(shiftRepository, times(1)).findById(15L);
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("Shift with id 15 not found", json.get("message"));
+        }
+
+        
+        // EDIT
+
+        @WithMockUser(roles = { "DRIVER" })
+        @Test
+        public void driver_can_edit_their_own_shift() throws Exception {
+                // arrange
+
+                long userId = currentUserService.getCurrentUser().getUser().getId();
+
+                Shift shift_original = Shift.builder()
+                                .driverID(userId)
+                                .day("Monday")
+                                .shiftStart("10:30AM")
+                                .shiftEnd("12:30PM")
+                                .driverBackupID(1)
+                                .build();
+
+                Shift shift_edited = Shift.builder()
+                                .driverID(userId)
+                                .day("Tuesday")
+                                .shiftStart("11:30AM")
+                                .shiftEnd("01:30PM")
+                                .driverBackupID(2)
+                                .build();
+
+                String requestBody = mapper.writeValueAsString(shift_edited);
+
+                when(shiftRepository.findById(eq(67L))).thenReturn(Optional.of(shift_original));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/shift?id=67")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(shiftRepository, times(1)).findById(eq(67L));
+                verify(shiftRepository, times(1)).save(shift_edited); // should be saved with correct user
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(requestBody, responseString);
+        }
+
+
+        
+
+        @WithMockUser(roles = { "DRIVER" })
+        @Test
+        public void driver_canot_edit_other_drivers_shift() throws Exception {
+                // arrange
+
+                long userId = currentUserService.getCurrentUser().getUser().getId();
+                long otherUserId = userId + 1;
+
+                Shift shift_original = Shift.builder()
+                                .driverID(otherUserId)
+                                .day("Monday")
+                                .shiftStart("10:30AM")
+                                .shiftEnd("12:30PM")
+                                .driverBackupID(1)
+                                .build();
+
+                Shift shift_edited = Shift.builder()
+                                .driverID(userId)
+                                .day("Tuesday")
+                                .shiftStart("11:30AM")
+                                .shiftEnd("01:30PM")
+                                .driverBackupID(1)
+                                .build();
+
+                String requestBody = mapper.writeValueAsString(shift_edited);
+
+                when(shiftRepository.findById(eq(67L))).thenReturn(Optional.of(shift_original));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/shift?id=67")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(shiftRepository, times(1)).findById(eq(67L));
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("Shift with id 67 not found", json.get("message"));
+        }
+
+        
+
+        @WithMockUser(roles = { "DRIVER" })
+        @Test
+        public void driver_cannot_edit_shift_that_does_not_exist() throws Exception {
+                // arrange
+
+                long userId = currentUserService.getCurrentUser().getUser().getId();
+
+                Shift shift_edited = Shift.builder()
+                                .driverID(userId)
+                                .day("Tuesday")
+                                .shiftStart("11:30AM")
+                                .shiftEnd("01:30PM")
+                                .driverBackupID(1)
+                                .build();
+
+
+                String requestBody = mapper.writeValueAsString(shift_edited);
+
+                when(shiftRepository.findById(eq(67L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/shift?id=67")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(shiftRepository, times(1)).findById(67L);
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("Shift with id 67 not found", json.get("message"));
+
+        }
+
+        
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void admin_can_edit_an_existing_shift() throws Exception {
+                // arrange
+
+                long userId = currentUserService.getCurrentUser().getUser().getId();
+                long otherUserId = userId + 1;
+
+                Shift shift_original = Shift.builder()
+                                .driverID(otherUserId)
+                                .day("Monday")
+                                .shiftStart("10:30AM")
+                                .shiftEnd("12:30PM")
+                                .driverBackupID(1)
+                                .build();
+
+                Shift shift_edited = Shift.builder()
+                                .driverID(userId)
+                                .day("Tuesday")
+                                .shiftStart("11:30AM")
+                                .shiftEnd("01:30PM")
+                                .driverBackupID(1)
+                                .build();
+
+                String requestBody = mapper.writeValueAsString(shift_edited);
+
+                when(shiftRepository.findById(eq(67L))).thenReturn(Optional.of(shift_original));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/shift?id=67")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(shiftRepository, times(1)).findById(67L);
+                verify(shiftRepository, times(1)).save(shift_edited); // should be saved with correct user
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(requestBody, responseString);
+        }
+
+
+
+
+
+
 }


### PR DESCRIPTION
In this PR I added the delete and update operations in the Shift controller, with the proper pre authorizations. I added pre authorization tests and mock data tests for both operations. Attached are screenshots of swagger endpoints.


<img width="1463" alt="Screenshot 2023-08-22 at 2 19 52 PM" src="https://github.com/ucsb-cs156-m23/proj-gauchoride-m23-9am-1/assets/108090479/d9fd12bb-df9f-4b8c-b444-5e2e8255e716">
<img width="1454" alt="Screenshot 2023-08-22 at 2 20 20 PM" src="https://github.com/ucsb-cs156-m23/proj-gauchoride-m23-9am-1/assets/108090479/7508e99b-14c4-4aa2-a5c7-94a5ee4a18a1">

Closes #26 
