### PR TITLE
Add Get all driver shifts method in Shift controller

### DIFF
--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/ShiftController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/ShiftController.java
@@ -65,6 +65,17 @@ public class ShiftController extends ApiController {
         return shift;
     }
 
+    @Operation(summary = "Get a list of all shifts for given driverId")
+    @PreAuthorize("hasRole('ROLE_DRIVER')")
+    @GetMapping("/drivershifts")
+    public ResponseEntity<String> driverShifts()
+            throws JsonProcessingException {
+        Long driverID = super.getCurrentUser().getUser().getId();
+        Iterable<Shift> shifts = shiftRepository.findByDriverID(driverID);
+        String body = mapper.writeValueAsString(shifts);
+        return ResponseEntity.ok().body(body);
+    }
+
     @Operation(summary = "Create a new shift for the table")
     @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER')")
     @PostMapping("/post")

--- a/src/main/java/edu/ucsb/cs156/gauchoride/interceptors/RoleInterceptor.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/interceptors/RoleInterceptor.java
@@ -56,6 +56,9 @@ public class RoleInterceptor implements HandlerInterceptor {
                 if (user.getDriver()) {
                     revisedAuthorities.add(new SimpleGrantedAuthority("ROLE_DRIVER"));
                 }
+                if (user.getRider()) {
+                    revisedAuthorities.add(new SimpleGrantedAuthority("ROLE_RIDER"));
+                }
                 Authentication newAuth = new OAuth2AuthenticationToken(principal, revisedAuthorities,
                         (((OAuth2AuthenticationToken) authentication).getAuthorizedClientRegistrationId()));
                 SecurityContextHolder.getContext().setAuthentication(newAuth);

--- a/src/main/java/edu/ucsb/cs156/gauchoride/interceptors/RoleInterceptor.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/interceptors/RoleInterceptor.java
@@ -56,9 +56,6 @@ public class RoleInterceptor implements HandlerInterceptor {
                 if (user.getDriver()) {
                     revisedAuthorities.add(new SimpleGrantedAuthority("ROLE_DRIVER"));
                 }
-                if (user.getRider()) {
-                    revisedAuthorities.add(new SimpleGrantedAuthority("ROLE_RIDER"));
-                }
                 Authentication newAuth = new OAuth2AuthenticationToken(principal, revisedAuthorities,
                         (((OAuth2AuthenticationToken) authentication).getAuthorizedClientRegistrationId()));
                 SecurityContextHolder.getContext().setAuthentication(newAuth);

--- a/src/main/java/edu/ucsb/cs156/gauchoride/repositories/ShiftRepository.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/repositories/ShiftRepository.java
@@ -10,5 +10,5 @@ import java.util.Optional;
 @Repository
 public interface ShiftRepository extends CrudRepository<Shift, Long> {
   Optional<Shift> findByDay(String day);
-  Optional<Shift> findByDriverID(Long driverID);
+  Iterable<Shift> findByDriverID(Long driverID);
 }

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/ShiftControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/ShiftControllerTests.java
@@ -99,6 +99,38 @@ public class ShiftControllerTests extends ControllerTestCase {
                                 .andExpect(status().is(404)); // logged, but no id exists
         }
 
+        // authorization tests for /drivershifts
+
+        @Test
+        public void logged_out_users_cannot_get_driver_shifts() throws Exception {
+                mockMvc.perform(get("/api/shift/drivershifts"))
+                                .andExpect(status().is(403)); 
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_cannot_get_driver_shifts() throws Exception {
+                mockMvc.perform(get("/api/shift/drivershifts"))
+                                .andExpect(status().is(403)); 
+        }
+
+
+        @WithMockUser(roles = { "DRIVER" })
+        @Test
+        public void logged_in_driver_can_get_driver_shifts() throws Exception {
+                mockMvc.perform(get("/api/shift/drivershifts"))
+                                .andExpect(status().is(200)); 
+        }
+
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void logged_in_admin_cannot_get_driver_shifts() throws Exception {
+                mockMvc.perform(get("/api/shift/drivershifts"))
+                                .andExpect(status().is(403)); 
+        }
+
+
+
         // Authorization tests for /api/shift/post
 
         @Test
@@ -420,6 +452,48 @@ public class ShiftControllerTests extends ControllerTestCase {
                 // assert
 
                 verify(shiftRepository, times(1)).findAll();
+                String expectedJson = mapper.writeValueAsString(expectedShifts);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        // GET DRIVER SHIFTS
+
+        @WithMockUser(roles = { "DRIVER" })
+        @Test
+        public void logged_in_driver_can_get_all_their_shifts() throws Exception {
+
+                long userId = currentUserService.getCurrentUser().getUser().getId();
+
+                Shift shift1 = Shift.builder()
+                                .driverID(userId)
+                                .day("Monday")
+                                .shiftStart("10:30AM")
+                                .shiftEnd("12:30PM")
+                                .driverBackupID(userId + 1)
+                                .build();
+
+                Shift shift2 = Shift.builder()
+                                .driverID(userId)
+                                .day("Tuesday")
+                                .shiftStart("10:30AM")
+                                .shiftEnd("12:30PM")
+                                .driverBackupID(userId + 1)
+                                .build();
+
+
+                ArrayList<Shift> expectedShifts = new ArrayList<>();
+                expectedShifts.addAll(Arrays.asList(shift1, shift2));
+
+                when(shiftRepository.findByDriverID(userId)).thenReturn(expectedShifts);
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/shift/drivershifts"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(shiftRepository, times(1)).findByDriverID(userId);
                 String expectedJson = mapper.writeValueAsString(expectedShifts);
                 String responseString = response.getResponse().getContentAsString();
                 assertEquals(expectedJson, responseString);


### PR DESCRIPTION
*** DO NOT MERGE UNTIL #33 is merged

In this PR I added a new method for getting all of a single drivers shifts, authorized by only a driver themselves. I added authorization tests and a single test for mock data. In the repository we had to change findByDriverId to return an iterable of all of a drivers shifts.

Closes #34 