### PR TITLE
added ROLE_RIDER to RoleInterceptor and tests

### DIFF
--- a/src/main/java/edu/ucsb/cs156/gauchoride/interceptors/RoleInterceptor.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/interceptors/RoleInterceptor.java
@@ -56,6 +56,9 @@ public class RoleInterceptor implements HandlerInterceptor {
                 if (user.getDriver()) {
                     revisedAuthorities.add(new SimpleGrantedAuthority("ROLE_DRIVER"));
                 }
+                if (user.getRider()) {
+                    revisedAuthorities.add(new SimpleGrantedAuthority("ROLE_RIDER"));
+                }
                 Authentication newAuth = new OAuth2AuthenticationToken(principal, revisedAuthorities,
                         (((OAuth2AuthenticationToken) authentication).getAuthorizedClientRegistrationId()));
                 SecurityContextHolder.getContext().setAuthentication(newAuth);

--- a/src/test/java/edu/ucsb/cs156/gauchoride/interceptors/RoleInterceptorTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/interceptors/RoleInterceptorTests.java
@@ -94,6 +94,7 @@ public class RoleInterceptorTests extends ControllerTestCase {
                                 .id(15L)
                                 .admin(false)
                                 .driver(true)
+                                .rider(false)
                                 .build();
                 when(userRepository.findByEmail("cgaucho@ucsb.edu")).thenReturn(Optional.of(user));
 
@@ -122,8 +123,54 @@ public class RoleInterceptorTests extends ControllerTestCase {
                                 .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_DRIVER"));
                 boolean role_member = authorities.stream()
                                 .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_MEMBER"));
+                boolean role_rider = authorities.stream()
+                                .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_RIDER"));
                 assertFalse(role_admin, "ROLE_ADMIN should not be in roles list");
                 assertTrue(role_driver, "ROLE_DRIVER should be in roles list");
+                assertTrue(role_member, "ROLE_MEMBER should be in roles list");
+                assertFalse(role_rider, "ROLE_RIDER should not be in roles list");
+        }
+                @Test
+        public void updates_rider_role_when_user_rider_false() throws Exception {
+                User user = User.builder()
+                                .email("cgaucho@ucsb.edu")
+                                .id(15L)
+                                .admin(false)
+                                .driver(false)
+                                .rider(true)
+                                .build();
+                when(userRepository.findByEmail("cgaucho@ucsb.edu")).thenReturn(Optional.of(user));
+
+                MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/currentUser");
+                HandlerExecutionChain chain = mapping.getHandler(request);
+                MockHttpServletResponse response = new MockHttpServletResponse();
+
+                assert chain != null;
+                Optional<HandlerInterceptor> RoleInterceptor = chain.getInterceptorList()
+                                .stream()
+                                .filter(RoleInterceptor.class::isInstance)
+                                .findFirst();
+
+                assertTrue(RoleInterceptor.isPresent());
+
+                RoleInterceptor.get().preHandle(request, response, chain.getHandler());
+
+                verify(userRepository, times(1)).findByEmail("cgaucho@ucsb.edu");
+
+                Collection<? extends GrantedAuthority> authorities = SecurityContextHolder.getContext()
+                                .getAuthentication().getAuthorities();
+
+                boolean role_admin = authorities.stream()
+                                .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_ADMIN"));
+                boolean role_driver = authorities.stream()
+                                .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_DRIVER"));
+                boolean role_member = authorities.stream()
+                                .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_MEMBER"));
+                boolean role_rider = authorities.stream()
+                                .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_RIDER"));
+                assertFalse(role_admin, "ROLE_ADMIN should not be in roles list");
+                assertFalse(role_driver, "ROLE_DRIVER should not be in roles list");
+                assertTrue(role_rider, "ROLE_RIDER should be in roles list");
                 assertTrue(role_member, "ROLE_MEMBER should be in roles list");
         }
 


### PR DESCRIPTION
As a Rider

I should be able to see and request rides

This needs to be separated from the role "ROLE_USER" in order to differentiate between just a logged in UCSB student and a Rider