### PR TITLE
Added GET /api/drivers/all and DriverController + Tests

### DIFF
--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriversController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriversController.java
@@ -1,0 +1,55 @@
+package edu.ucsb.cs156.gauchoride.controllers;
+
+import java.util.ArrayList;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import edu.ucsb.cs156.gauchoride.entities.User;
+import edu.ucsb.cs156.gauchoride.repositories.UserRepository;
+
+import edu.ucsb.cs156.gauchoride.errors.EntityNotFoundException;
+
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+
+
+@Tag(name = "Driver Controller")
+@RequestMapping("/api/drivers")
+@RestController
+public class DriversController extends ApiController {
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    ObjectMapper mapper;
+
+    @Operation(summary = "Get a list of all drivers")
+    @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER') || hasRole('ROLE_RIDER')")
+    @GetMapping("/all")
+    public ResponseEntity<String> drivers()
+            throws JsonProcessingException {
+        ArrayList<User> driverUsers = new ArrayList<User>();
+        Iterable<User> users = userRepository.findAll();
+        for (User user : users) {
+            if(user.getDriver()) {
+                driverUsers.add(user);
+            }
+        }
+        
+        String body = mapper.writeValueAsString(driverUsers);
+        return ResponseEntity.ok().body(body);
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriversControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriversControllerTests.java
@@ -1,0 +1,95 @@
+package edu.ucsb.cs156.gauchoride.controllers;
+
+import edu.ucsb.cs156.gauchoride.ControllerTestCase;
+import edu.ucsb.cs156.gauchoride.controllers.DriversController;
+import edu.ucsb.cs156.gauchoride.models.CurrentUser;
+import edu.ucsb.cs156.gauchoride.repositories.UserRepository;
+import edu.ucsb.cs156.gauchoride.testconfig.TestConfig;
+import org.springframework.http.MediaType;
+
+import edu.ucsb.cs156.gauchoride.entities.User;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import java.util.ArrayList;
+
+@WebMvcTest(controllers = DriversController.class)
+@Import(TestConfig.class)
+public class DriversControllerTests extends ControllerTestCase {
+
+  @MockBean
+  UserRepository userRepository;
+
+    @Test
+    public void logged_out_users_cannot_see_drivers() throws Exception {
+                mockMvc.perform(get("/api/drivers/all"))
+                                .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles={"USER"})
+    @Test
+    public void normal_user_cannot_see_drivers() throws Exception {
+                mockMvc.perform(get("/api/drivers/all"))
+                                .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "DRIVER" })
+    @Test
+    public void driver_can_see_drivers() throws Exception {
+      User testUser1 = User.builder()
+                          .id(1)
+                          .email("cgaucho@ucsb.edu")
+                          .cellPhone("18002738255")
+                          .driver(true)
+                          .build();
+      User testUser2 = User.builder()
+                          .id(1)
+                          .email("cgaucho2@ucsb.edu")
+                          .cellPhone("988")
+                          .driver(false)
+                          .build();
+      ArrayList<User> combined = new ArrayList<>();
+      combined.add(testUser1);
+      combined.add(testUser2);
+      ArrayList<User> expectedOut = new ArrayList<>();
+      expectedOut.add(testUser1);
+      when(userRepository.findAll()).thenReturn(combined);
+      MvcResult response = mockMvc.perform(get("/api/drivers/all"))
+                                  .andExpect(status().isOk()).andReturn();
+      verify(userRepository, times(1)).findAll();
+      String expectedJson = mapper.writeValueAsString(expectedOut);
+      String responseString = response.getResponse().getContentAsString();
+      assertEquals(expectedJson,responseString);
+    }
+
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void admin_can_see_drivers() throws Exception {
+                  mockMvc.perform(get("/api/drivers/all"))
+                                  .andExpect(status().is(200));
+    }
+    
+    @WithMockUser(roles = { "RIDER" })
+    @Test
+    public void rider_can_see_drivers() throws Exception {
+                  mockMvc.perform(get("/api/drivers/all"))
+                                  .andExpect(status().is(200));
+    }
+}


### PR DESCRIPTION
In this PR, I added a GET route /api/drivers/all to get a list of all Users that are Drivers. Only logged in Riders, Drivers, and Admins can access this GET route. Screenshot of swagger below.

<img width="1512" alt="Screenshot 2023-08-25 at 4 45 31 AM" src="https://github.com/ucsb-cs156-m23/proj-gauchoride-m23-9am-1/assets/40775364/1f95ca2f-83f0-452a-a1c0-7babe9c2f158">

Closes #55 
