### PR TITLE
Added navbar element for Drivers list and placeholder for Drivers Page @ /drivers

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -16,6 +16,7 @@ import ShiftPage from "main/pages/ShiftPage";
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
 import "bootstrap/dist/css/bootstrap.css";
+import DriversListPage from "main/pages/DriversListPage";
 
 
 function App() {
@@ -47,6 +48,15 @@ function App() {
         }
         {
           hasRole(currentUser, "ROLE_RIDER") && <Route exact path="/shift/list" element={<ShiftPage />} />
+        }
+        {
+          hasRole(currentUser, "ROLE_ADMIN") && <Route exact path="/drivers" element={<DriversListPage />} />
+        }
+        {
+          hasRole(currentUser, "ROLE_DRIVER") && <Route exact path="/drivers" element={<DriversListPage />} />
+        }
+        {
+          hasRole(currentUser, "ROLE_RIDER") && <Route exact path="/drivers" element={<DriversListPage />} />
         }
         {
           hasRole(currentUser, "ROLE_USER")

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -89,7 +89,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
               }
               {
                 isParticipant(currentUser) && (
-                  <Nav.Link data-testid="appnavbar-driver-link" href="/drivers">Drivers</Nav.Link>
+                  <Nav.Link data-testid="appnavbar-driver-link" href="/drivers">Drivers List</Nav.Link>
                 )
               }
               {

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -82,6 +82,11 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
               }
               {
                 isParticipant(currentUser) && (
+                  <Nav.Link data-testid="appnavbar-driver-link" href="/drivers">Drivers</Nav.Link>
+                )
+              }
+              {
+                isParticipant(currentUser) && (
                   <NavDropdown title="Ride Request" id="appnavbar-ride-dropdown" data-testid="appnavbar-ride-dropdown" >
                     <NavDropdown.Item data-testid="appnavbar-ride-dropdown-rides" as={Link} to="/ride/">Rides</NavDropdown.Item>
                     { createRideRequest(currentUser) }

--- a/frontend/src/main/pages/DriversListPage.js
+++ b/frontend/src/main/pages/DriversListPage.js
@@ -1,0 +1,13 @@
+  // Stryker disable all : placeholder page
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function DriversListPage() {
+
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Drivers Page not yet Implemented</h1>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -176,6 +176,86 @@ describe("AppNavbar tests", () => {
         expect(shiftMenu).not.toBeInTheDocument();        
     });
 
+
+
+
+
+
+    test("renders drivers link correctly for admin user", async () => {
+
+        const currentUser = currentUserFixtures.adminOnly;
+        const doLogin = jest.fn();
+
+        const { getByText , getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} doLogin={doLogin} />
+                    </MemoryRouter>
+            </QueryClientProvider>
+        );
+        
+        await waitFor(() => expect(getByText("Welcome, Phill Conrad")).toBeInTheDocument());
+        const driverLink = getByTestId("appnavbar-driver-link");
+        expect(driverLink).toBeInTheDocument();        
+    });
+
+    test("renders drivers link correctly for driver", async () => {
+
+        const currentUser = currentUserFixtures.driverOnly;
+        const doLogin = jest.fn();
+
+        const { getByText , getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+        
+        await waitFor(() => expect(getByText("Welcome, Phillip Conrad")).toBeInTheDocument());
+        const driverLink = getByTestId("appnavbar-driver-link");
+        expect(driverLink).toBeInTheDocument();           
+    });
+
+    test("renders drivers link correctly for rider", async () => {
+
+        const currentUser = currentUserFixtures.riderOnly;
+        const doLogin = jest.fn();
+
+        const { getByText , getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+        
+        await waitFor(() => expect(getByText("Welcome, Phillip Conrad")).toBeInTheDocument());
+        const driverLink = getByTestId("appnavbar-driver-link");
+        expect(driverLink).toBeInTheDocument();         
+    });
+
+    test("not render drivers link for regular user", async () => {
+
+        const currentUser = currentUserFixtures.userOnly;
+        const doLogin = jest.fn();
+
+        const { getByText } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+        
+        await waitFor(() => expect(getByText("Welcome, Phillip Conrad")).toBeInTheDocument());
+        const driverLink = screen.queryByTestId("appnavbar-driver-link");
+        expect(driverLink).not.toBeInTheDocument();        
+    });
+
+
+
+
     // test taken from https://github.com/ucsb-cs156/proj-courses repo
     test("renders image correctly", async () => {
         const currentUser = currentUserFixtures.adminUser;

--- a/frontend/src/tests/pages/DriversListPage.test.js
+++ b/frontend/src/tests/pages/DriversListPage.test.js
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import DriversListPage from "main/pages/DriversListPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+
+describe("PlaceholderIndexPage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const queryClient = new QueryClient();
+    test("Renders expected content", () => {
+        // arrange
+
+        setupUserOnly();
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <DriversListPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        expect(screen.getByText("Drivers Page not yet Implemented")).toBeInTheDocument();
+    });
+
+});

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriversController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriversController.java
@@ -1,0 +1,55 @@
+package edu.ucsb.cs156.gauchoride.controllers;
+
+import java.util.ArrayList;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import edu.ucsb.cs156.gauchoride.entities.User;
+import edu.ucsb.cs156.gauchoride.repositories.UserRepository;
+
+import edu.ucsb.cs156.gauchoride.errors.EntityNotFoundException;
+
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+
+
+@Tag(name = "Driver Controller")
+@RequestMapping("/api/drivers")
+@RestController
+public class DriversController extends ApiController {
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    ObjectMapper mapper;
+
+    @Operation(summary = "Get a list of all drivers")
+    @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER') || hasRole('ROLE_RIDER')")
+    @GetMapping("/all")
+    public ResponseEntity<String> drivers()
+            throws JsonProcessingException {
+        ArrayList<User> driverUsers = new ArrayList<User>();
+        Iterable<User> users = userRepository.findAll();
+        for (User user : users) {
+            if(user.getDriver()) {
+                driverUsers.add(user);
+            }
+        }
+        
+        String body = mapper.writeValueAsString(driverUsers);
+        return ResponseEntity.ok().body(body);
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriversControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriversControllerTests.java
@@ -1,0 +1,95 @@
+package edu.ucsb.cs156.gauchoride.controllers;
+
+import edu.ucsb.cs156.gauchoride.ControllerTestCase;
+import edu.ucsb.cs156.gauchoride.controllers.DriversController;
+import edu.ucsb.cs156.gauchoride.models.CurrentUser;
+import edu.ucsb.cs156.gauchoride.repositories.UserRepository;
+import edu.ucsb.cs156.gauchoride.testconfig.TestConfig;
+import org.springframework.http.MediaType;
+
+import edu.ucsb.cs156.gauchoride.entities.User;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import java.util.ArrayList;
+
+@WebMvcTest(controllers = DriversController.class)
+@Import(TestConfig.class)
+public class DriversControllerTests extends ControllerTestCase {
+
+  @MockBean
+  UserRepository userRepository;
+
+    @Test
+    public void logged_out_users_cannot_see_drivers() throws Exception {
+                mockMvc.perform(get("/api/drivers/all"))
+                                .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles={"USER"})
+    @Test
+    public void normal_user_cannot_see_drivers() throws Exception {
+                mockMvc.perform(get("/api/drivers/all"))
+                                .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "DRIVER" })
+    @Test
+    public void driver_can_see_drivers() throws Exception {
+      User testUser1 = User.builder()
+                          .id(1)
+                          .email("cgaucho@ucsb.edu")
+                          .cellPhone("18002738255")
+                          .driver(true)
+                          .build();
+      User testUser2 = User.builder()
+                          .id(1)
+                          .email("cgaucho2@ucsb.edu")
+                          .cellPhone("988")
+                          .driver(false)
+                          .build();
+      ArrayList<User> combined = new ArrayList<>();
+      combined.add(testUser1);
+      combined.add(testUser2);
+      ArrayList<User> expectedOut = new ArrayList<>();
+      expectedOut.add(testUser1);
+      when(userRepository.findAll()).thenReturn(combined);
+      MvcResult response = mockMvc.perform(get("/api/drivers/all"))
+                                  .andExpect(status().isOk()).andReturn();
+      verify(userRepository, times(1)).findAll();
+      String expectedJson = mapper.writeValueAsString(expectedOut);
+      String responseString = response.getResponse().getContentAsString();
+      assertEquals(expectedJson,responseString);
+    }
+
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void admin_can_see_drivers() throws Exception {
+                  mockMvc.perform(get("/api/drivers/all"))
+                                  .andExpect(status().is(200));
+    }
+    
+    @WithMockUser(roles = { "RIDER" })
+    @Test
+    public void rider_can_see_drivers() throws Exception {
+                  mockMvc.perform(get("/api/drivers/all"))
+                                  .andExpect(status().is(200));
+    }
+}


### PR DESCRIPTION
In this PR, I added a navbar element for the Drivers list page at /drivers. Added routes to App.js to serve a placeholder page for admins, drivers, and riders. + Tests.

<img width="1512" alt="Screenshot 2023-08-25 at 6 16 37 AM" src="https://github.com/ucsb-cs156-m23/proj-gauchoride-m23-9am-1/assets/40775364/888e6ca5-f5d9-4db8-a8b3-da48e82906e8">


Closes #56 
