### PR TITLE
Implemented driver dashboard page and dashboard page tests

### DIFF
--- a/frontend/src/main/pages/Drivers/driverDashboardPage.js
+++ b/frontend/src/main/pages/Drivers/driverDashboardPage.js
@@ -1,13 +1,26 @@
-import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import React from 'react'
+import ShiftTable from "main/components/Shift/ShiftTable"
 
+
+import BasicLayout from 'main/layouts/BasicLayout/BasicLayout';
+import { useBackend } from "main/utils/useBackend";
 export default function DriverDashboardPage() {
-
-  // Stryker disable all : placeholder for future implementation
+    const { data: shift, error: _error, status: _status } =
+    useBackend(
+        // Stryker disable next-line all : don't test internal caching of React Query
+        ["/api/shift/drivershifts"],
+        // Stryker disable next-line StringLiteral,ObjectLiteral : since "GET" is default, "" is an equivalent mutation
+        { method: "GET", url: "/api/shift/drivershifts" },
+        []
+    );
+   
+  
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Driver Dashboard Page not yet implemented</h1>
+        <h1>Your Shifts</h1>
+        <ShiftTable shift={shift} />
       </div>
     </BasicLayout>
   )
-}
+};

--- a/frontend/src/tests/pages/Drivers/driverDashboardPage.test.js
+++ b/frontend/src/tests/pages/Drivers/driverDashboardPage.test.js
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, waitFor } from "@testing-library/react";
 import DriverDashboardPage from "main/pages/Drivers/driverDashboardPage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
@@ -7,10 +7,35 @@ import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import shiftFixtures from "fixtures/shiftFixtures";
+import mockConsole from "jest-mock-console";
 
-describe("PlaceholderCreatePage tests", () => {
 
-    const axiosMock = new AxiosMockAdapter(axios);
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
+
+describe("DriverDashBoardPage tests", () => {
+
+    const axiosMock =new AxiosMockAdapter(axios);
+
+    const testId = "ShiftTable";
 
     const setupUserOnly = () => {
         axiosMock.reset();
@@ -19,13 +44,25 @@ describe("PlaceholderCreatePage tests", () => {
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
     };
 
-    const queryClient = new QueryClient();
-    test("Renders expected content", () => {
-        // arrange
+    const setupDriverOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.driverOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
 
-        setupUserOnly();
-       
-        // act
+    const setupAdminUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    test("renders without crashing for driver", () => {
+        setupDriverOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/shift/drivershifts").reply(200, []);
+
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
@@ -34,8 +71,49 @@ describe("PlaceholderCreatePage tests", () => {
             </QueryClientProvider>
         );
 
-        // assert
-        expect(screen.getByText("Driver Dashboard Page not yet implemented")).toBeInTheDocument();
+
     });
+
+
+    test("renders three rides without crashing for driver", async () => {
+        setupDriverOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/shift/drivershifts").reply(200, shiftFixtures.threeShifts);
+
+        const { getByText } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <DriverDashboardPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => expect(getByText("Shift")).toBeInTheDocument());
+
+
+    });
+
+    test("renders empty table when backend unavailable", async () => {
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/shift/drivershifts").timeout();
+
+        const restoreConsole = mockConsole();
+
+        const { queryByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <DriverDashboardPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1); });
+        restoreConsole();
+
+        expect(queryByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
+
+    });
+
+ 
 
 });

--- a/frontend/src/tests/pages/Drivers/driverDashboardPage.test.js
+++ b/frontend/src/tests/pages/Drivers/driverDashboardPage.test.js
@@ -37,12 +37,7 @@ describe("DriverDashBoardPage tests", () => {
 
     const testId = "ShiftTable";
 
-    const setupUserOnly = () => {
-        axiosMock.reset();
-        axiosMock.resetHistory();
-        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
-        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-    };
+   
 
     const setupDriverOnly = () => {
         axiosMock.reset();
@@ -51,12 +46,7 @@ describe("DriverDashBoardPage tests", () => {
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
     };
 
-    const setupAdminUser = () => {
-        axiosMock.reset();
-        axiosMock.resetHistory();
-        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
-        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-    };
+   
 
     test("renders without crashing for driver", () => {
         setupDriverOnly();


### PR DESCRIPTION
In this PR I utilized a backend endpoint in order to display all personal shifts on a personalized driver dashboard page. Also wrote tests for the dashboard page. 

![image](https://github.com/ucsb-cs156-m23/proj-gauchoride-m23-9am-1/assets/97569267/8a30e262-f44d-4433-a126-389b310416e5)
